### PR TITLE
Update base-microservice dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.idrsolutions</groupId>
     <artifactId>jpedal-microservice-example</artifactId>
     <packaging>war</packaging>
-    <version>8.0.0</version>
+    <version>8.0.1</version>
     <name>JPedal Microservice Example</name>
 
     <dependencies>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.idrsolutions</groupId>
             <artifactId>base-microservice-example</artifactId>
-            <version>12.0.1</version>
+            <version>12.0.2</version>
         </dependency>
         <dependency>
             <groupId>jpedal</groupId>


### PR DESCRIPTION
Update the base-microservice version to apply the JSON parser decimal number fix (see https://github.com/idrsolutions/base-microservice-example/pull/76)